### PR TITLE
Added supportedOS win8 win81

### DIFF
--- a/Src/mdUmmm.bas
+++ b/Src/mdUmmm.bas
@@ -488,6 +488,10 @@ Private Function pvDumpSupportedOs(sOsType As String, cOutput As Collection) As 
         sOutput = "<supportedOS Id=""{e2011457-1546-43c5-a5fe-008deee3d3f0}""/>"
     Case "win7"
         sOutput = "<supportedOS Id=""{35138b9a-5d96-4fbd-8e2d-a2440225f93a}""/>"
+    Case "win8"
+        sOutput = "<supportedOS Id=""{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}""/>"
+    Case "win81"
+        sOutput = "<supportedOS Id=""{1f676c76-80e1-4239-95bb-83d0f6d0da78}""/>"
     End Select
     If LenB(sOutput) <> 0 Then
         cOutput.Add "    <compatibility xmlns=""urn:schemas-microsoft-com:compatibility.v1"">"


### PR DESCRIPTION
GetVersionEx returns 6.2 (Windows 8) under Windows 8.1 unless supportedOS for Windows 8.1 is targeted in manifest.
