### PR TITLE
Added longPathAware support

### DIFF
--- a/Src/mdUmmm.bas
+++ b/Src/mdUmmm.bas
@@ -162,6 +162,10 @@ Private Function pvProcess(sFile As String) As String
                 '--- supportedos <os_types>
                 '---   os_types are | separated OSes from { vista, win7, win8, win81 } or guids
                 pvDumpSupportedOs vRow, cOutput
+            Case "longpathaware"
+                '--- longpathaware [on_off]
+                '---   on_off is true/false or 0/1
+                pvDumpLongPathAware C_Bool(At(vRow, 1)), C_Bool(At(vRow, 2)), cOutput
             End Select
         Next
     Case 0
@@ -524,6 +528,27 @@ Private Function pvDumpDpiAware(ByVal bAware As Boolean, ByVal bPerMonitor As Bo
     End If
     '--- success
     pvDumpDpiAware = True
+    Exit Function
+EH:
+    PrintError FUNC_NAME
+    Resume Next
+End Function
+
+Private Function pvDumpLongPathAware(ByVal bAware As Boolean, ByVal bPerMonitor As Boolean, cOutput As Collection) As Boolean
+    Const FUNC_NAME     As String = "pvDumpLongPathAware"
+    '--- note: longPathAware details from MS here:
+    '---   https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN
+    '---   Requires Windows 10, version 1607 or newer and HKLM\SYSTEM\CurrentControlSet\Control\FileSystem LongPathsEnabled = 1
+    On Error GoTo EH
+    If bAware Then
+        cOutput.Add "    <application xmlns=""urn:schemas-microsoft-com:asm.v3"">"
+        cOutput.Add "        <windowsSettings xmlns:ws2=""http://schemas.microsoft.com/SMI/2016/WindowsSettings"">"
+        cOutput.Add "            <ws2:longPathAware>true</ws2:longPathAware>"
+        cOutput.Add "        </windowsSettings>"
+        cOutput.Add "    </application>"
+    End If
+    '--- success
+    pvDumpLongPathAware = True
     Exit Function
 EH:
     PrintError FUNC_NAME


### PR DESCRIPTION
Greetings Vladimir - for your consideration I've added support to UMMM for the longPathAware element.

Notes:
	See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN

	The above page claims:
		1) Requires Windows 10, version 1607 or newer.
		2) HKLM\SYSTEM\CurrentControlSet\Control\FileSystem LongPathsEnabled = 1.
		3) The application manifest must also include the longPathAware element.

	In my tests though, the manifest did not seem to be needed for long paths to work with the "\\?\" path prefix, so I'm not sure if this change is even necessary. However, I've done this work to conform with Microsoft's documentation.

	Lastly, I emit the manifest exactly as specified in the above link as:

		<application xmlns="urn:schemas-microsoft-com:asm.v3">
			<windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
		        		<ws2:longPathAware>true</ws2:longPathAware>
			</windowsSettings>
		</application>

	But perhaps, we can use the "asmv3:" shorthand as follows?

		<asmv3:application>
			<asmv3:windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
			        <ws2:longPathAware>true</ws2:longPathAware>
			</asmv3:windowsSettings>
		</asmv3:application>

Signed-off-by: Jason Peter Brown <jason@bitspaces.com>